### PR TITLE
Change hex2nix to use hex.pm registry snapshot.

### DIFF
--- a/src/hex2nix.erl
+++ b/src/hex2nix.erl
@@ -35,7 +35,7 @@
 %%
 %% Variables
 %%
--define(REGISTRY_URL, "https://s3.amazonaws.com/s3.hex.pm/registry.ets.gz").
+-define(REGISTRY_URL, "https://raw.githubusercontent.com/erlang-nix/hex-pm-registry-snapshots/master/registry.ets.gz").
 -define(OPTIONS,
         [
          {output_path, $o, "output-path", {string, "./"}


### PR DESCRIPTION
This ensures that the registry used in builds of rebar3 packages in
nixpkgs is the same as the one used to create hex-packages.nix files.