### PR TITLE
Implement override mechanism

### DIFF
--- a/src/h2n_generate.erl
+++ b/src/h2n_generate.erl
@@ -32,10 +32,10 @@
 nix_expression(Deps0, Failing) ->
     Deps1 = sort_and_dedup_deps(Deps0),
     Doc = above(above(header(Failing),
-                      nest(par([sep([text("self"), text("="), text("rec {")])
+                      nest(par([sep([text("packages"), text("="), text("self: rec {")])
                                , nest(create_body(Deps1))
                                , break(text("};"))]))),
-                text("in self")),
+                text("in stdenv.lib.fix' (stdenv.lib.extends overrides packages)")),
     prettypr:format(Doc).
 
 %% ============================================================================
@@ -189,7 +189,7 @@ header(Failing) ->
     Header = [text("/* hex-packages.nix is an auto-generated file -- DO NOT EDIT! */")
              , text("")
              , list_failing(Failing)
-             , blank_line(text("{ stdenv, callPackage }:"))
+             , blank_line(text("{ stdenv, callPackage, overrides ? (self: super: {}) }:"))
              , text("let")],
     vertical_list(Header).
 

--- a/src/h2n_generate.erl
+++ b/src/h2n_generate.erl
@@ -36,7 +36,9 @@ nix_expression(Deps0, Failing) ->
                                , nest(create_body(Deps1))
                                , break(text("};"))]))),
                 text("in stdenv.lib.fix' (stdenv.lib.extends overrides packages)")),
-    prettypr:format(Doc).
+    Pretty = prettypr:format(Doc),
+    Pretty1 = re:replace(Pretty, "\t", "        ", [global]),
+    re:replace(Pretty1, "\\h+\\n", "\n", [global]).
 
 %% ============================================================================
 %% Internal Functions


### PR DESCRIPTION
Adding overrides argument to hex-packages.nix allows to override generated packages from outside of this file. This will be used to fixup packages for which there's not enough information in rebar.config to build it - e.g. to deal with native dependencies.
