### PR TITLE
Remove dependency on buildHex + Bug Fix

### DIFF
--- a/src/h2n_fetcher.erl
+++ b/src/h2n_fetcher.erl
@@ -174,6 +174,8 @@ analyze_rebar_config(TempDirectory) ->
     end.
 
 -spec simplify_plugin(atom() | {atom(), any(), any()}) -> binary().
+simplify_plugin({Name, _Vsn}) when is_atom(Name) ->
+    atom_to_binary(Name, latin1);
 simplify_plugin({Name, _Vsn, _Vcs}) when is_atom(Name) ->
     atom_to_binary(Name, latin1);
 simplify_plugin(Name) when is_atom(Name) ->
@@ -397,6 +399,7 @@ parse_license1(_Name, <<"agpl 3.0">>) -> <<"agpl3">>;
 parse_license1(_Name, <<"afl-2.1">>) -> <<"afl21">>;
 parse_license1(_Name, <<"afl 2.1">>) -> <<"afl21">>;
 parse_license1(_Name, <<"apache 2">>) -> <<"apsl20">>;
+parse_license1(_Name, <<"apache">>) -> <<"apsl20">>;
 parse_license1(_Name, <<"unlicense">>) -> <<"unlicense">>;
 parse_license1(_Name, <<"mozilla public license 1.1">>) -> <<"mpl11">>;
 parse_license1(_Name, <<"isc">>) -> <<"isc">>;

--- a/src/h2n_fetcher.erl
+++ b/src/h2n_fetcher.erl
@@ -408,6 +408,7 @@ parse_license1(_Name, <<"mit">>) -> <<"mit">>;
 parse_license1(_Name, <<"bsd">>) -> <<"bsd3">>;
 parse_license1(_Name, <<"wtfpl">>) -> <<"wtfpl">>;
 parse_license1(_Name, <<"the mit license">>) -> <<"mit">>;
+parse_license1(_Name, <<"same as elixir">>) -> <<"asl20">>;
 parse_license1(Name, License) ->
     io:format("Unable to parse license ~s for ~s. Using "
               "'Unspecified free software license'~n", [License, Name]),

--- a/src/h2n_generate.erl
+++ b/src/h2n_generate.erl
@@ -76,15 +76,10 @@ format_position(_, _, _) ->
     empty().
 
 -spec app_body(h2n_fetcher:dep_despc(), [binary()]) -> prettypr:document().
-app_body(Dep = #dep_desc{app = {Name, Vsn},
-                         build_plugins = BuildPlugins,
-                         sha = Sha},
-         Deps) ->
+app_body(Dep = #dep_desc{build_plugins = BuildPlugins}, Deps) ->
     erlang_deps(Deps),
-    par([break(sep([text("buildHex"), text("{")]))
-        , nest(par([key_value(<<"name">>, Name)
-                   , key_value(<<"version">>, Vsn)
-                   , key_value(<<"sha256">>, Sha)
+    par([break(sep([text("buildRebar3"), text("{")]))
+        , nest(par([src(Dep)
                    , format_compile_port(Dep)
                    , build_plugins(BuildPlugins)
                    , erlang_deps(Deps)
@@ -96,6 +91,18 @@ format_compile_port(#dep_desc{has_native_code = true}) ->
     break(follow(text(["compilePorts", " ="]), text("true;")));
 format_compile_port(_) ->
     empty().
+
+-spec src(h2n_fetcher:dep_despc()) -> prettypr:document().
+src(#dep_desc{app = {Name, Vsn},
+                         sha = Sha}) ->
+    par([sep([text("src")
+             , text("=")
+             , text("fetchHex")
+             , text("{")])
+        , nest(par([key_value(<<"name">>, Name)
+                   , key_value(<<"version">>, Vsn)
+                   , key_value(<<"sha256">>, Sha)]))
+        , text("};")]).
 
 -spec meta(h2n_fetcher:dep_despc()) -> prettypr:document().
 meta(#dep_desc{description = Description
@@ -160,8 +167,9 @@ key_value(Key, Value) ->
 
 -spec section_header([binary()]) -> prettypr:document().
 section_header(Deps) ->
-    sep([text("{")
-        , nest(expand_arg_list([<<"buildHex">> | Deps], ",", []))
+    sep([text("{ ")
+        , nest(expand_arg_list([<<"buildRebar3">>,
+                                <<"fetchHex">> | Deps], ",", []))
         , text("}:")]).
 
 -spec expand_arg_list([binary()], string(), [prettypr:document()]) ->

--- a/src/h2n_util.erl
+++ b/src/h2n_util.erl
@@ -46,8 +46,10 @@ iolist_to_list(Value) ->
                                 {ok, [{binary(), jsx:json_term()}]} | unconvertable.
 json_to_assoc_list(Value) when erlang:is_list(Value) ->
     {ok, Value};
-json_to_assoc_list(_) ->
-    unconvertable.
+json_to_assoc_list(null) ->
+    {ok, []};
+json_to_assoc_list(Unconvertable) ->
+    {unconvertable, Unconvertable}.
 
 -spec json_get_assoc_list(binary(), jsx:json_term()) ->
                                  {ok, [{binary(), jsx:json_term()}]}


### PR DESCRIPTION
buildHex is going away with the new elixir support that is in the works. This removes that dependency from hex2nix.