### PR TITLE
Add user-agent header.

### DIFF
--- a/src/h2n_fetcher.erl
+++ b/src/h2n_fetcher.erl
@@ -81,7 +81,7 @@ get_registry(ShouldCache, HexRegistry) ->
                          , [HexRegistry, TempDirectory]),
                 {ok, "200", _, {file, GzippedFileName}} =
                     ibrowse:send_req(HexRegistry
-                                    , []
+                                    , [{"User-Agent", "hex2nix"}]
                                     , get
                                     , []
                                     , [{save_response_to_file,
@@ -167,7 +167,7 @@ get_app_detail_from_hex_pm(AppName) ->
                 Url = h2n_util:iolist_to_list(["https://hex.pm/api/packages/"
                                               , AppName]),
                 ibrowse:send_req(Url
-                                , [{"Accept", "application/json"}]
+                                , [{"User-Agent", "hex2nix"}, {"Accept", "application/json"}]
                                 , get
                                 , []
                                 , h2n_util:get_ibrowse_http_env())
@@ -197,7 +197,7 @@ get_deep_meta_for_package(AppName, AppVsn, AllApps) ->
     io:format("Pulling From ~s to ~s~n"
              , [Url, TargetPath]),
     case ibrowse:send_req(Url
-                         , []
+                         , [{"User-Agent", "hex2nix"}]
                          , get
                          , []
                          , [{save_response_to_file,


### PR DESCRIPTION
Fix for the following when running hex2nix:

```
Fetching phoenix_jsroutes 0.0.4 details from hex.pm.
escript: exception error: no case clause matching 
                 {ok,"400",
                     [{"Connection","keep-alive"},
                      {"Server","Cowboy"},
                      {"Date","Thu, 13 Oct 2016 14:10:47 GMT"},
                      {"Content-Length","56"},
                      {"Content-Type","application/json; charset=utf-8"},
                      {"Cache-Control","max-age=0, private, must-revalidate"},
                      {"Strict-Transport-Security","max-age=31536000"},
                      {"Via","1.1 vegur"}],
                     "{\"status\":400,\"message\":\"User-Agent header is requried\"}"}
  in function  h2n_fetcher:get_app_detail_from_hex_pm/1 (/tmp/nix-build-hex2nix-e3b987309d321176bb5cb543565c73522fc22ce3.drv-0/hex2nix-e3b987309d321176bb5cb543565c73522fc22ce3-src/_build/default/lib/hex2nix/src/h2n_fetcher.erl, line 175)
  in call from h2n_fetcher:decorate_app/2 (/tmp/nix-build-hex2nix-e3b987309d321176bb5cb543565c73522fc22ce3.drv-0/hex2nix-e3b987309d321176bb5cb543565c73522fc22ce3-src/_build/default/lib/hex2nix/src/h2n_fetcher.erl, line 146)
  in call from lists:filtermap/2 (lists.erl, line 1316)
  in call from hex2nix:do_main/1 (/tmp/nix-build-hex2nix-e3b987309d321176bb5cb543565c73522fc22ce3.drv-0/hex2nix-e3b987309d321176bb5cb543565c73522fc22ce3-src/_build/default/lib/hex2nix/src/hex2nix.erl, line 103)
  in call from escript:run/2 (escript.erl, line 757)
  in call from escript:start/1 (escript.erl, line 277)
  in call from init:start_it/1 
  in call from init:start_em/1 
```