### PR TITLE
Pin dependency versions

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {erl_opts, [debug_info,
             warn_missing_spec_all,
             warnings_as_errors]}.
-{deps, [ ibrowse
-       , jsx
-       , erlware_commons
-       , getopt]}.
+{deps, [ {ibrowse, "4.2.2"}
+       , {jsx, "2.8.0"}
+       , {erlware_commons, "1.0.0"}
+       , {getopt, "0.8.2"}]}.


### PR DESCRIPTION
Unpinned dependency versions can cause build issues in Nix if the
package registry index snapshot contains a newer version than what is
packaged in nixpkgs.

See nixos/nixpkgs#43430 for context.

The versions chosen here are the most recent ones currently packaged
in nixpkgs, with the exception of ibrowse which has been pinned to a
version that is not affected by cmullaparthi/ibrowse#160.