### PR TITLE
OTP 22 compatibility

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,5 +3,5 @@
             warnings_as_errors]}.
 {deps, [ {ibrowse, "4.2.2"}
        , {jsx, "2.8.0"}
-       , {erlware_commons, "1.0.0"}
+       , {erlware_commons, "1.2.0"}
        , {getopt, "0.8.2"}]}.


### PR DESCRIPTION
This bumps erlware_commons to 1.2.0