### PR TITLE
replace lib:nonl/1 with string:chomp/1

### DIFF
--- a/src/h2n_util.erl
+++ b/src/h2n_util.erl
@@ -120,7 +120,7 @@ json_get_list(Key, Object) ->
 
 -spec temp_directory() -> string().
 temp_directory() ->
-    lib:nonl(cmd("mktemp -d")).
+    string:chomp(cmd("mktemp -d")).
 
 -spec cmd(string()) -> string().
 cmd(Cmd) ->


### PR DESCRIPTION
lib:nonl was removed with Erlang R21 and can be replaced with
string:chomp/1 (https://erldocs.com/21.0/stdlib/string.html).

From http://erlang.org/download/otp_src_21.0.readme:

  OTP-15072    Application(s): stdlib
               Related Id(s): 1786, OTP-15114, PR

               The lib module is removed:
               ...
               -- lib:nonl/1 is removed.

Addresses issue #28.